### PR TITLE
[HSDEV-3341][HSDEV-2133][TC] pause audio/video when transmitting nacks

### DIFF
--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -80,7 +80,8 @@ func (n *ResponderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) int
 		}
 		go func() {
 			lastBurstPackets := 0
-			if n.resendMutex != nil && len(pkts) > 0 {
+			nacksLock, _ := strconv.ParseBool(os.Getenv("HYPERSCALE_NACKS_LOCK"))
+			if nacksLock && n.resendMutex != nil && len(pkts) > 0 {
 				n.resendMutex.Lock()
 				defer n.resendMutex.Unlock()
 			}
@@ -169,7 +170,8 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack, last
 	logNacks := os.Getenv("HYPERSCALE_LOG_NACKED_PACKETS") == "true"
 	nacksSpreadDelayMs, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS")) // 0 is returned on error, in which case feature will be ignored later on
 	nacksMaxPacketsBurst, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_MAX_PACKET_BURST"))     // 0 is returned on error, in which case feature will be ignored later on
-	dropPercentage, _ := strconv.ParseFloat(os.Getenv("HYPERSCALE_DROPPED_PACKET_PERCENTAGE"), 64)
+	dropPercentage, _ := strconv.ParseFloat(os.Getenv("HYPERSCALE_NACKS_DROPPED_PACKET_PERCENTAGE"), 64)
+
 	packetsSentWithoutDelay = *lastBurstPackets
 	pairsCount := len(nack.Nacks)
 	for i := range nack.Nacks {

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -2,6 +2,7 @@ package nack
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strconv"
 	"sync"
@@ -77,14 +78,21 @@ func (n *ResponderInterceptor) BindRTCPReader(reader interceptor.RTCPReader) int
 		if err != nil {
 			return 0, nil, err
 		}
-		for _, rtcpPacket := range pkts {
-			nack, ok := rtcpPacket.(*rtcp.TransportLayerNack)
-			if !ok {
-				continue
+		go func() {
+			lastBurstPackets := 0
+			if n.resendMutex != nil && len(pkts) > 0 {
+				n.resendMutex.Lock()
+				defer n.resendMutex.Unlock()
 			}
 
-			go n.resendPackets(nack)
-		}
+			for _, rtcpPacket := range pkts {
+				nack, ok := rtcpPacket.(*rtcp.TransportLayerNack)
+				if !ok {
+					continue
+				}
+				n.resendPackets(nack, &lastBurstPackets)
+			}
+		}()
 
 		return i, attr, err
 	})
@@ -105,18 +113,34 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 
 	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
 		sendBuffer.add(&rtp.Packet{Header: *header, Payload: payload})
-
 		percentage, _ := strconv.ParseFloat(os.Getenv("HYPERSCALE_DROPPED_PACKET_PERCENTAGE"), 64)
-		if percentage > 0 && 100/percentage > 0 &&
-			header.SequenceNumber%(uint16(100/percentage)) == 0 {
-			log.WithFields(
-				log.Fields{
-					"subcomponent":            "interceptor",
-					"sequenceNumber":          header.SequenceNumber,
-					"droppedPacketPercentage": percentage,
-					"type":                    "INTENSIVE",
-				}).Warnf("dropping rtp packet with SN %d intentially..", header.SequenceNumber)
-			return 0, nil
+		if percentage > 0 && percentage <= 100 {
+			drop := false
+			// Switch between 3 modes of packet dropping every 20 second. (periods are 0s-19s, 20s-39s, 40s-59s)
+			mode := int(time.Now().Unix() % 60 / 20)
+			switch mode {
+			case 0:
+				// Drop random percentage of packets
+				drop = float64(rand.Intn(100)+1) <= percentage
+			case 1:
+				// Drop sequencial percentage of packets
+				drop = header.SequenceNumber%100 < uint16(percentage)
+			case 2:
+				// Drop a packet every Nth packet percentage (e.g. 30% will drop every 30th packet)
+				drop = (int(header.SequenceNumber) % int(100/percentage)) == 0
+			}
+
+			if drop {
+				log.WithFields(
+					log.Fields{
+						"subcomponent":            "interceptor",
+						"sequenceNumber":          header.SequenceNumber,
+						"droppedPacketPercentage": percentage,
+						"mode":                    mode,
+						"type":                    "INTENSIVE",
+					}).Warnf("dropping rtp packet with SN %d intentionally..", header.SequenceNumber)
+				return 0, nil
+			}
 		}
 
 		return writer.Write(header, payload, attributes)
@@ -130,7 +154,7 @@ func (n *ResponderInterceptor) UnbindLocalStream(info *interceptor.StreamInfo) {
 	n.streamsMu.Unlock()
 }
 
-func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
+func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack, lastBurstPackets *int) {
 	var nacksSpreadDelayMs int
 	var nacksMaxPacketsBurst int
 	var packetsSentWithoutDelay int
@@ -143,14 +167,11 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
 	extensionId, idErr := getEnvVal("HYPERSCALE_RTP_EXTENSION_SAMPLE_ATTR_ID")
 	retransmitPos, posErr := getEnvVal("HYPERSCALE_RTP_EXTENSION_RETRANSMIT_ATTR_POS")
 	logNacks := os.Getenv("HYPERSCALE_LOG_NACKED_PACKETS") == "true"
-	nacksSpreadDelayMs, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_SPREAD_PACKETS_DELAY_MS")) // 0 is returned on error, in which case feature will be ignored later on
-	nacksMaxPacketsBurst, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_MAX_PACKET_BURST"))      // 0 is returned on error, in which case feature will be ignored later on
-
-	packetsSentWithoutDelay = 0
-	if n.resendMutex != nil {
-		n.resendMutex.Lock()
-		defer n.resendMutex.Unlock()
-	}
+	nacksSpreadDelayMs, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS")) // 0 is returned on error, in which case feature will be ignored later on
+	nacksMaxPacketsBurst, _ = strconv.Atoi(os.Getenv("HYPERSCALE_NACKS_MAX_PACKET_BURST"))     // 0 is returned on error, in which case feature will be ignored later on
+	dropPercentage, _ := strconv.ParseFloat(os.Getenv("HYPERSCALE_DROPPED_PACKET_PERCENTAGE"), 64)
+	packetsSentWithoutDelay = *lastBurstPackets
+	pairsCount := len(nack.Nacks)
 	for i := range nack.Nacks {
 		if logNacks {
 			log.WithFields(
@@ -161,7 +182,7 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
 					"mediaSsrc":    nack.MediaSSRC,
 					"lostPackets":  fmt.Sprintf("%d: %b", nack.Nacks[i].PacketID, nack.Nacks[i].LostPackets),
 					"type":         "INTENSIVE",
-				}).Debugf("responsing to nack %v..", nack.Nacks[i])
+				}).Debugf("responsing to nack pair %d/%d..", i+1, pairsCount)
 		}
 		nack.Nacks[i].Range(func(seq uint16) bool {
 			if p := stream.sendBuffer.get(seq); p != nil {
@@ -181,12 +202,22 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
 						"payloadType":    p.PayloadType,
 						"ssrc":           p.SSRC,
 						"sequenceNumber": seq,
+						"nackPairIdx":    i,
 						"type":           "INTENSIVE",
 					})
+
+				if dropPercentage > 0 && dropPercentage <= 100 && float64(rand.Intn(100)+1) <= dropPercentage {
+					line.Warnf("dropping rtp nack packet with SN %d intentionally..", seq)
+					packetsSentWithoutDelay++ // From testing spread prespective, count this dropped nack packet as it was re-transmitted
+					*lastBurstPackets = packetsSentWithoutDelay
+					return true
+				}
+
 				if nacksMaxPacketsBurst > 0 && nacksSpreadDelayMs > 0 && packetsSentWithoutDelay >= nacksMaxPacketsBurst {
 					packetsSentWithoutDelay = 0
 					time.Sleep(time.Duration(nacksSpreadDelayMs) * time.Millisecond)
 				}
+
 				if _, err := stream.rtpWriter.Write(&p.Header, p.Payload, interceptor.Attributes{}); err != nil {
 					n.log.Warnf("failed resending nacked packet: %+v", err)
 					if logNacks {
@@ -195,7 +226,7 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
 				} else {
 					packetsSentWithoutDelay++
 					if logNacks {
-						line.Debugf("retransmit rtp packet %d..", seq)
+						line.Debugf("retransmitted rtp packet %d..", seq)
 					}
 				}
 			} else {
@@ -208,6 +239,7 @@ func (n *ResponderInterceptor) resendPackets(nack *rtcp.TransportLayerNack) {
 						}).Warnf("failed to get packet with SN %d from internal buffer..", seq)
 				}
 			}
+			*lastBurstPackets = packetsSentWithoutDelay
 			return true
 		})
 	}

--- a/pkg/nack/responder_interceptor_test.go
+++ b/pkg/nack/responder_interceptor_test.go
@@ -105,8 +105,8 @@ func TestResponderInterceptorNacksSpreadEnabled(t *testing.T) {
 
 	os.Setenv("HYPERSCALE_NACKS_MAX_PACKET_BURST", "10")
 	defer os.Unsetenv("HYPERSCALE_NACKS_MAX_PACKET_BURST")
-	os.Setenv("HYPERSCALE_NACKS_SPREAD_PACKETS_DELAY_MS", "1000")
-	defer os.Unsetenv("HYPERSCALE_NACKS_SPREAD_PACKETS_DELAY_MS")
+	os.Setenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS", "1000")
+	defer os.Unsetenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS")
 
 	nackWriteTimePhasesSecsCount := []int{0, 0, 0, 0, 0, 0, 0} // Stores 7s count of recieved nacks in 1s buckets
 	timeNacksStart := time.Now()
@@ -185,8 +185,8 @@ func TestResponderInterceptorNacksSpreadDisabled(t *testing.T) {
 
 	os.Setenv("HYPERSCALE_NACKS_MAX_PACKET_BURST", "0")
 	defer os.Unsetenv("HYPERSCALE_NACKS_MAX_PACKET_BURST")
-	os.Setenv("HYPERSCALE_NACKS_SPREAD_PACKETS_DELAY_MS", "0")
-	defer os.Unsetenv("HYPERSCALE_NACKS_SPREAD_PACKETS_DELAY_MS")
+	os.Setenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS", "0")
+	defer os.Unsetenv("HYPERSCALE_NACKS_SPREAD_PACKET_DELAY_MS")
 
 	// Send nack report for 64 missing packets
 	stream.ReceiveRTCP([]rtcp.Packet{

--- a/pkg/nack/responder_option.go
+++ b/pkg/nack/responder_option.go
@@ -1,6 +1,10 @@
 package nack
 
-import "github.com/pion/logging"
+import (
+	"sync"
+
+	"github.com/pion/logging"
+)
 
 // ResponderOption can be used to configure ResponderInterceptor
 type ResponderOption func(s *ResponderInterceptor) error
@@ -10,6 +14,13 @@ type ResponderOption func(s *ResponderInterceptor) error
 func ResponderSize(size uint16) ResponderOption {
 	return func(r *ResponderInterceptor) error {
 		r.size = size
+		return nil
+	}
+}
+
+func ResponderResendMutex(resendMutex *sync.Mutex) ResponderOption {
+	return func(r *ResponderInterceptor) error {
+		r.resendMutex = resendMutex
 		return nil
 	}
 }


### PR DESCRIPTION
@erivni 

1. Support 3 different modes for dropped percentage packets which rotates every 20s. (random percentage, every Nth packet percentage, sequential percentage)
2. Support percentage configuration to drop nack packets as well
3. Support configuration to  use shared lock while sending nacks (Shared lock will be used when TC writes ABR samples)