### PR TITLE
[HSDEV-9294] Configure some gcc delay controller config params

### DIFF
--- a/pkg/gcc/delay_based_bwe.go
+++ b/pkg/gcc/delay_based_bwe.go
@@ -47,6 +47,7 @@ type delayControllerConfig struct {
 	maxBitrate                    int
 	overuseTime                   int
 	disableMeasurementUncertainty bool
+	rateCalculatorWindow          int
 }
 
 func newDelayController(c delayControllerConfig) *delayController {
@@ -74,7 +75,7 @@ func newDelayController(c delayControllerConfig) *delayController {
 	slopeEstimator := newSlopeEstimator(newKalman(setDisableMeasurementUncertaintyUpdates(c.disableMeasurementUncertainty)), overuseDetector.onDelayStats)
 	arrivalGroupAccumulator := newArrivalGroupAccumulator()
 
-	rc := newRateCalculator(500 * time.Millisecond)
+	rc := newRateCalculator(time.Duration(c.rateCalculatorWindow) * time.Millisecond)
 
 	delayController.wg.Add(2)
 	go func() {

--- a/pkg/gcc/delay_based_bwe.go
+++ b/pkg/gcc/delay_based_bwe.go
@@ -41,10 +41,12 @@ type delayController struct {
 }
 
 type delayControllerConfig struct {
-	nowFn          now
-	initialBitrate int
-	minBitrate     int
-	maxBitrate     int
+	nowFn                         now
+	initialBitrate                int
+	minBitrate                    int
+	maxBitrate                    int
+	overuseTime                   int
+	disableMeasurementUncertainty bool
 }
 
 func newDelayController(c delayControllerConfig) *delayController {
@@ -68,8 +70,8 @@ func newDelayController(c delayControllerConfig) *delayController {
 		}
 	})
 	delayController.rateController = rateController
-	overuseDetector := newOveruseDetector(newAdaptiveThreshold(), 10*time.Millisecond, rateController.onDelayStats)
-	slopeEstimator := newSlopeEstimator(newKalman(), overuseDetector.onDelayStats)
+	overuseDetector := newOveruseDetector(newAdaptiveThreshold(), time.Duration(c.overuseTime)*time.Millisecond, rateController.onDelayStats)
+	slopeEstimator := newSlopeEstimator(newKalman(setDisableMeasurementUncertaintyUpdates(c.disableMeasurementUncertainty)), overuseDetector.onDelayStats)
 	arrivalGroupAccumulator := newArrivalGroupAccumulator()
 
 	rc := newRateCalculator(500 * time.Millisecond)

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -75,7 +75,7 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 	zms := float64(z.Microseconds()) / 1000.0
 
 	if !k.disableMeasurementUncertaintyUpdates {
-		alpha := math.Pow((1 - chi), 30.0/(1000.0*5*float64(time.Millisecond)))
+		alpha := math.Pow((1 - chi), 25.0/(1000.0*5*float64(time.Millisecond)))
 		root := math.Sqrt(k.measurementUncertainty)
 		root3 := 3 * root
 		if zms > root3 {

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -136,7 +136,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 func (c *rateController) increase(now time.Time) int {
 	if c.latestDecreaseRate.average > 0 && float64(c.latestReceivedRate) > c.latestDecreaseRate.average-3*c.latestDecreaseRate.stdDeviation &&
 		float64(c.latestReceivedRate) < c.latestDecreaseRate.average+3*c.latestDecreaseRate.stdDeviation {
-		bitsPerFrame := float64(c.target) / 30.0
+		bitsPerFrame := float64(c.target) / 25.0
 		packetsPerFrame := math.Ceil(bitsPerFrame / (1200 * 8))
 		expectedPacketSizeBits := bitsPerFrame / packetsPerFrame
 

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -56,6 +56,9 @@ type SendSideBWE struct {
 	minBitrate    int
 	maxBitrate    int
 
+	overuseTime                   int
+	disableMeasurementUncertainty bool
+
 	close     chan struct{}
 	closeLock sync.RWMutex
 }
@@ -103,21 +106,32 @@ func SendSideBWELossBasedOptions(options *LossBasedBandwidthEstimatorOptions) Op
 	}
 }
 
+// SendSideBWELossBasedOptions sets the different configuration values for the loss based algorithm
+func SendSideBWEDelayControllerOptions(overuseTime int, disableMeasurementUncertainty bool) Option {
+	return func(e *SendSideBWE) error {
+		e.overuseTime = overuseTime
+		e.disableMeasurementUncertainty = disableMeasurementUncertainty
+		return nil
+	}
+}
+
 // NewSendSideBWE creates a new sender side bandwidth estimator
 func NewSendSideBWE(opts ...Option) (*SendSideBWE, error) {
 	e := &SendSideBWE{
-		pacer:                 nil,
-		lossController:        nil,
-		lossControllerOptions: nil,
-		delayController:       nil,
-		feedbackAdapter:       cc.NewFeedbackAdapter(),
-		onTargetBitrateChange: nil,
-		lock:                  sync.Mutex{},
-		latestStats:           Stats{},
-		latestBitrate:         latestBitrate,
-		minBitrate:            minBitrate,
-		maxBitrate:            maxBitrate,
-		close:                 make(chan struct{}),
+		pacer:                         nil,
+		lossController:                nil,
+		lossControllerOptions:         nil,
+		delayController:               nil,
+		feedbackAdapter:               cc.NewFeedbackAdapter(),
+		onTargetBitrateChange:         nil,
+		lock:                          sync.Mutex{},
+		latestStats:                   Stats{},
+		latestBitrate:                 latestBitrate,
+		minBitrate:                    minBitrate,
+		maxBitrate:                    maxBitrate,
+		overuseTime:                   10,
+		disableMeasurementUncertainty: false,
+		close:                         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		if err := opt(e); err != nil {
@@ -129,10 +143,12 @@ func NewSendSideBWE(opts ...Option) (*SendSideBWE, error) {
 	}
 	e.lossController = newLossBasedBWE(e.latestBitrate, e.lossControllerOptions)
 	e.delayController = newDelayController(delayControllerConfig{
-		nowFn:          time.Now,
-		initialBitrate: e.latestBitrate,
-		minBitrate:     e.minBitrate,
-		maxBitrate:     e.maxBitrate,
+		nowFn:                         time.Now,
+		initialBitrate:                e.latestBitrate,
+		minBitrate:                    e.minBitrate,
+		maxBitrate:                    e.maxBitrate,
+		overuseTime:                   e.overuseTime,
+		disableMeasurementUncertainty: e.disableMeasurementUncertainty,
 	})
 
 	e.delayController.onUpdate(e.onDelayUpdate)

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -58,6 +58,7 @@ type SendSideBWE struct {
 
 	overuseTime                   int
 	disableMeasurementUncertainty bool
+	rateCalculatorWindow          int
 
 	close     chan struct{}
 	closeLock sync.RWMutex
@@ -107,10 +108,11 @@ func SendSideBWELossBasedOptions(options *LossBasedBandwidthEstimatorOptions) Op
 }
 
 // SendSideBWELossBasedOptions sets the different configuration values for the loss based algorithm
-func SendSideBWEDelayControllerOptions(overuseTime int, disableMeasurementUncertainty bool) Option {
+func SendSideBWEDelayControllerOptions(overuseTime int, disableMeasurementUncertainty bool, rateCalculatorWindow int) Option {
 	return func(e *SendSideBWE) error {
 		e.overuseTime = overuseTime
 		e.disableMeasurementUncertainty = disableMeasurementUncertainty
+		e.rateCalculatorWindow = rateCalculatorWindow
 		return nil
 	}
 }
@@ -131,6 +133,7 @@ func NewSendSideBWE(opts ...Option) (*SendSideBWE, error) {
 		maxBitrate:                    maxBitrate,
 		overuseTime:                   10,
 		disableMeasurementUncertainty: false,
+		rateCalculatorWindow:          500,
 		close:                         make(chan struct{}),
 	}
 	for _, opt := range opts {
@@ -149,6 +152,7 @@ func NewSendSideBWE(opts ...Option) (*SendSideBWE, error) {
 		maxBitrate:                    e.maxBitrate,
 		overuseTime:                   e.overuseTime,
 		disableMeasurementUncertainty: e.disableMeasurementUncertainty,
+		rateCalculatorWindow:          e.rateCalculatorWindow,
 	})
 
 	e.delayController.onUpdate(e.onDelayUpdate)


### PR DESCRIPTION
Add more configured constants for delay controller config
Update hard-coded 30 fps to 25. I don't see a reason to configure this as 25 is our configured value. But, I'm ok to do it if required @erivni 