### PR TITLE
[HSDEV-10004] - GCC to use a single bucket manager for bitrate and backoff

### DIFF
--- a/pkg/gcc/delay_based_bwe.go
+++ b/pkg/gcc/delay_based_bwe.go
@@ -24,6 +24,7 @@ type DelayStats struct {
 	TargetBitrate   int
 	ReceivedBitrate int
 	LatestRTT       time.Duration
+	BucketStatus    string
 }
 
 type now func() time.Time

--- a/pkg/gcc/delay_based_bwe.go
+++ b/pkg/gcc/delay_based_bwe.go
@@ -54,7 +54,7 @@ type delayControllerConfig struct {
 	rateControllerOptions         *RateControllerBucketsOptions
 }
 
-func newDelayController(c delayControllerConfig) *delayController {
+func newDelayController(c delayControllerConfig, bitrateControlBucketsManager *Manager) *delayController {
 	ackPipe := make(chan []cc.Acknowledgment)
 	ackRatePipe := make(chan []cc.Acknowledgment)
 
@@ -68,7 +68,7 @@ func newDelayController(c delayControllerConfig) *delayController {
 		log:                     logging.NewDefaultLoggerFactory().NewLogger("gcc_delay_controller"),
 	}
 
-	rateController := newRateControllerBuckets(c.nowFn, c.initialBitrate, c.minBitrate, c.maxBitrate, c.rateControllerOptions, func(ds DelayStats) {
+	rateController := newRateControllerBuckets(c.nowFn, c.initialBitrate, c.minBitrate, c.maxBitrate, c.rateControllerOptions, bitrateControlBucketsManager, func(ds DelayStats) {
 		delayController.log.Infof("delaystats: %v", ds)
 		if delayController.onUpdateCallback != nil {
 			delayController.onUpdateCallback(ds)

--- a/pkg/gcc/loss_based_bwe.go
+++ b/pkg/gcc/loss_based_bwe.go
@@ -135,7 +135,7 @@ func (e *lossBasedBandwidthEstimator) updateLossEstimate(results []cc.Acknowledg
 			}
 		}
 	} else if decreaseLoss > e.options.DecreaseLossThreshold {
-		if time.Since(e.lastDecrease) > e.options.DecreaseTimeThreshold {
+		if time.Since(e.lastDecrease) > e.options.DecreaseTimeThreshold && e.bitrate > e.minBitrate {
 			e.bitrateControlBucketsManager.HandleBitrateDecrease(uint64(e.bitrate))
 			e.log.Infof("loss controller decreasing; averageLoss: %v, decreaseLoss: %v, increaseLoss: %v", e.averageLoss, decreaseLoss, increaseLoss)
 			e.lastDecrease = time.Now()

--- a/pkg/gcc/loss_based_bwe.go
+++ b/pkg/gcc/loss_based_bwe.go
@@ -89,11 +89,11 @@ func (e *lossBasedBandwidthEstimator) getEstimate(wantedRate int) LossStats {
 		e.bitrate = clampInt(wantedRate, e.minBitrate, e.maxBitrate)
 	}
 
-	if (wantedRate < e.bitrate) {
-		e.bitrateControlBucketsManager.HandleBitrateDecrease(uint64(e.bitrate))
-		e.lastDecrease = time.Now()
-		e.bitrate = wantedRate
-	}
+	// if (wantedRate < e.bitrate) {
+	// 	e.bitrateControlBucketsManager.HandleBitrateDecrease(uint64(e.bitrate))
+	// 	e.lastDecrease = time.Now()
+	// 	e.bitrate = wantedRate
+	// }
 
 	return LossStats{
 		TargetBitrate: e.bitrate,

--- a/pkg/gcc/loss_based_bwe.go
+++ b/pkg/gcc/loss_based_bwe.go
@@ -177,7 +177,7 @@ func (e *lossBasedBandwidthEstimator) updateLossEstimate(results []cc.Acknowledg
 		if time.Since(e.lastDecrease) > e.options.DecreaseTimeThreshold {
 			e.log.Infof("loss controller decreasing; averageLoss: %v, decreaseLoss: %v, increaseLoss: %v, currentBitrate: %v", e.averageLoss, decreaseLoss, increaseLoss, e.bitrate)
 			e.lastDecrease = time.Now()
-			e.bitrate = clampInt(int(float64(e.bitrate)*(1-0.5*decreaseLoss)), e.minBitrate, e.maxBitrate)
+			e.bitrate = clampInt(int(float64(e.bitrate)*(1-1*decreaseLoss)), e.minBitrate, e.maxBitrate)
 			// currentBitrateBucket, _ := e.bitrateControlBucketsManager.getBucket(uint64(e.bitrate))
 			// newBitrateBucket, _ := e.bitrateControlBucketsManager.getBucket(uint64(e.bitrate))
 			// if currentBitrateBucket != newBitrateBucket {

--- a/pkg/gcc/rate_controller_buckets.go
+++ b/pkg/gcc/rate_controller_buckets.go
@@ -173,7 +173,7 @@ func (c *rateControllerBuckets) onDelayStats(ds DelayStats) {
 
 func (c *rateControllerBuckets) increase(now time.Time) int {
 	rate := c.target
-	if time.Since(c.lastIncrease) > c.rateControllerOptions.IncreaseTimeThreshold {
+	if time.Since(c.lastIncrease) > c.rateControllerOptions.IncreaseTimeThreshold && time.Since(c.lastDecrease) > c.rateControllerOptions.DecreaseTimeThreshold {
 		c.lastIncrease = time.Now()
 		rate = c.target + c.rateControllerOptions.IncreaseBitrateChange
 	}

--- a/pkg/gcc/rate_controller_buckets.go
+++ b/pkg/gcc/rate_controller_buckets.go
@@ -105,18 +105,26 @@ func (c *rateControllerBuckets) onDelayStats(ds DelayStats) {
 	c.delayStats = ds
 	c.delayStats.State = c.delayStats.State.transition(ds.Usage)
 
-	if c.delayStats.State == stateHold {
-		c.bitrateControlBucketsManager.HandleBitrateNormal(uint64(c.target))
-		return
-	}
-
 	var next DelayStats
 
 	c.lock.Lock()
 
 	switch c.delayStats.State {
 	case stateHold:
-		// should never occur due to check above, but makes the linter happy
+		c.bitrateControlBucketsManager.HandleBitrateNormal(uint64(c.target))
+
+		next = DelayStats{
+			Measurement:      c.delayStats.Measurement,
+			Estimate:         c.delayStats.Estimate,
+			Threshold:        c.delayStats.Threshold,
+			LastReceiveDelta: c.delayStats.LastReceiveDelta,
+			Usage:            c.delayStats.Usage,
+			State:            c.delayStats.State,
+			TargetBitrate:    c.target,
+			ReceivedBitrate:  c.latestReceivedRate,
+			LatestRTT:        c.latestRTT,
+		}
+		
 	case stateIncrease:
 		c.bitrateControlBucketsManager.HandleBitrateNormal(uint64(c.target))
 

--- a/pkg/gcc/rate_controller_buckets_test.go
+++ b/pkg/gcc/rate_controller_buckets_test.go
@@ -44,11 +44,19 @@ func TestRateControllerBucketsRun(t *testing.T) {
 		t0 = t0.Add(100 * time.Millisecond)
 		return t0
 	}
+	manager := NewManager(&BitrateControlBucketsConfig{
+		BitrateStableThreshold:              5 * 25,
+		HandleUnstableBitrateGracePeriodSec: 2,
+		BitrateBucketIncrement:              250000,
+		BackoffDurationsSec:                 []float64{0, 0, 15, 30, 60},
+	})
+	manager.InitializeBuckets(uint64(maxBitrate))
+	
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			out := make(chan DelayStats)
-			dc := newRateControllerBuckets(mockNoFn, 100_000, 1_000, 50_000_000, nil, func(ds DelayStats) {
+			dc := newRateControllerBuckets(mockNoFn, 100_000, 1_000, 50_000_000, nil, manager, func(ds DelayStats) {
 				out <- ds
 			})
 			in := make(chan DelayStats)

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -339,6 +339,7 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 	}
 
 	if time.Since(e.lastBucketUpdate) > time.Duration(1 * time.Second) {
+		e.lastBucketUpdate = time.Now()
 		e.lossController.handleBitrate()
 		e.delayController.rateController.handleBitrate()
 	}

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -100,6 +100,14 @@ func SendSideBWEMinBitrate(rate int) Option {
 	}
 }
 
+// SendSideBWEBucketConfig sets the config for the bucket manager
+func SendSideBWEBucketConfig(bitrateControlBuckets *BitrateControlBucketsConfig) Option {
+	return func(e *SendSideBWE) error {
+		e.bitrateControlBuckets = bitrateControlBuckets
+		return nil
+	}
+}
+
 // SendSideBWEPacer sets the pacing algorithm to use.
 func SendSideBWEPacer(p Pacer) Option {
 	return func(e *SendSideBWE) error {
@@ -117,13 +125,12 @@ func SendSideBWELossBasedOptions(options *LossBasedBandwidthEstimatorOptions) Op
 }
 
 // SendSideBWELossBasedOptions sets the different configuration values for the loss based algorithm
-func SendSideBWEDelayControllerOptions(overuseTime int, disableMeasurementUncertainty bool, rateCalculatorWindow int, rateControllerOptions *RateControllerBucketsOptions, bitrateControlBuckets *BitrateControlBucketsConfig) Option {
+func SendSideBWEDelayControllerOptions(overuseTime int, disableMeasurementUncertainty bool, rateCalculatorWindow int, rateControllerOptions *RateControllerBucketsOptions) Option {
 	return func(e *SendSideBWE) error {
 		e.overuseTime = overuseTime
 		e.disableMeasurementUncertainty = disableMeasurementUncertainty
 		e.rateCalculatorWindow = rateCalculatorWindow
 		e.rateControllerOptions = rateControllerOptions
-		e.bitrateControlBuckets = bitrateControlBuckets
 		return nil
 	}
 }
@@ -163,7 +170,7 @@ func NewSendSideBWE(opts ...Option) (*SendSideBWE, error) {
 			BitrateStableThreshold:              10,
 			HandleUnstableBitrateGracePeriodSec: 5,
 			BitrateBucketIncrement:              250000,
-			BackoffDurationsSec:                 []float64{0, 30, 300, 1800},
+			BackoffDurationsSec:                 []float64{0, 60, 300, 1800},
 		}
 	}
 

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -350,7 +350,7 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 	bitrateChanged := false
 	bitrate := minInt(delayStats.TargetBitrate, lossStats.TargetBitrate)
 	
-	e.delayController.rateController.handleBitrate(bitrate)
+	e.delayController.rateController.updateBitrate(bitrate)
 
 	if time.Since(e.lastBucketUpdate) > time.Duration(1*time.Second) {
 		e.lastBucketUpdate = time.Now()
@@ -362,9 +362,6 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 			e.bitrateControlBucketsManager.HandleBitrateDecrease(e.lastBucketUpdateBitrate)
 		}
 		e.lastBucketUpdateBitrate = latestBitrate
-
-		// e.lossController.handleBitrate()
-		// e.delayController.rateController.handleBitrate()
 	}
 
 	if bitrate != e.latestBitrate {


### PR DESCRIPTION
Basic idea is to lower bitrate based on either controller update but use a single bucket manager to flag the bitrate as a stable/unstable. The controllers use the manager to check if it's able to increase.
If both allow increase, it increases
If either lowers bitrate, the lower is taken

* Add bucket status to statistic logs
* Sync delay and loss controller bitrates
